### PR TITLE
ignoring eclipse generated metadata files

### DIFF
--- a/YamlUtility/.gitignore
+++ b/YamlUtility/.gitignore
@@ -1,0 +1,4 @@
+/target/
+.classpath
+.project
+.settings/


### PR DESCRIPTION
the .gitignore is ignoring some of the eclipse metadata files such as:

.classpath
.project
.settings/

This way these generated files won't get in your way when you are committing your changes in git.